### PR TITLE
Another prototd prototype using wot.ThingDescription and proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,13 @@
 *.dylib
 
 # Test binary, built with `go test -c`
+*.proto
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.json
+*.jsonld
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# pb-td-gen
-A simple command line tool to generate a Thing Description from Protocol Buffers
+grpc-wot
+---
+This project contains a support tool for adapting gRPC communications in the W3C Web of Things ecosystem.
+
+See [cmd/protod](/Interactions-HSG/grpc-wot/blob/main/cmd/prototd) for the command line tool to translate a gRPC service to a Web Thing.
+
+## Synopsis
+
+### Install
+
+```console
+go get -u github.com/Interactions-HSG/grpc-wot/...
+```
+

--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,140 @@
+package grpcwot
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/Interactions-HSG/grpcwot/pkg/protofmt"
+	"github.com/emicklei/proto"
+	"github.com/linksmart/thing-directory/wot"
+)
+
+type builder struct {
+	td   wot.ThingDescription
+	ds   map[string]*wot.DataSchema
+	ip   string
+	port int
+}
+
+func newBuilder(ip string, port int) *builder {
+	return &builder{
+		td:   wot.ThingDescription{},
+		ds:   map[string]*wot.DataSchema{},
+		ip:   ip,
+		port: port,
+	}
+}
+
+// GetIRI returns the target IRI for the RPC
+func (b *builder) GetIRI(rpcName string) string {
+	return fmt.Sprintf("http://%s:%d/%s/%s", b.ip, b.port, b.td.Title, rpcName)
+}
+
+// HandleService assigns the Title for the resulting TD
+func (b *builder) HandleService(s *proto.Service) {
+	b.td.Title = s.Name
+}
+
+// HandleRPC constructs Interaction Affordances with prefetched DataSchema
+func (b *builder) HandleRPC(r *proto.RPC) {
+	// TODO: affordance classification should happen here
+	// putting all RPC to Actions for now
+	if b.td.Actions == nil {
+		b.td.Actions = map[string]wot.ActionAffordance{}
+	}
+	affordance := wot.ActionAffordance{}
+	affordance.Input = *b.ds[r.RequestType]
+	affordance.Output = *b.ds[r.ReturnsType]
+	affordance.Forms = []wot.Form{
+		{
+			Href:        b.GetIRI(r.Name),
+			ContentType: "application/grpc+proto",
+			Op:          []string{"writeproperty"},
+		},
+	}
+
+	b.td.Actions[r.Name] = affordance
+}
+
+// HandleMessage build a DataSchema: https://www.w3.org/TR/wot-thing-description/#dataschema
+// from a Message in the protobuf definition
+func (b *builder) HandleMessage(m *proto.Message) {
+	if _, ok := b.ds[m.Name]; !ok {
+		b.ds[m.Name] = &wot.DataSchema{
+			DataType: "object",
+			ObjectSchema: &wot.ObjectSchema{
+				Properties: map[string]wot.DataSchema{},
+			},
+		}
+	}
+	for _, v := range m.Elements {
+		switch protofmt.NameOfVisitee(v) {
+		case "NormalField":
+			b.ds[m.Name].ObjectSchema.Properties[v.(*proto.NormalField).Field.Name] =
+				fieldToDataSchema(v.(*proto.NormalField).Field)
+		case "Comment":
+		case "Oneof":
+			b.ds[m.Name].ObjectSchema.Properties[v.(*proto.Oneof).Name] =
+				wot.DataSchema{OneOf: oneofToDataSchema(v.(*proto.Oneof))}
+		}
+	}
+}
+
+func fieldToDataSchema(f *proto.Field) wot.DataSchema {
+	switch f.Type {
+	case "bool":
+		return wot.DataSchema{DataType: "boolean"}
+	case "float":
+		return wot.DataSchema{DataType: "number"}
+	case "int32":
+		return wot.DataSchema{DataType: "integer"}
+	default:
+		return wot.DataSchema{DataType: "string"}
+	}
+}
+
+func oneofToDataSchema(oo *proto.Oneof) []wot.DataSchema {
+	oof := []wot.DataSchema{}
+	for _, v := range oo.Elements {
+		oof = append(oof, fieldToDataSchema(v.(*proto.OneOfField).Field))
+	}
+	return oof
+}
+
+// GenerateTDfromProtoBuf parses `protoFile` to generate `tdFile`
+func GenerateTDfromProtoBuf(protoFile, tdFile, ip string, port int) error {
+	// initialize the TD builder with an empty TD and DataSchema
+	b := newBuilder(ip, port)
+
+	// parse the protoFile with the emicklei/proto
+	reader, _ := os.Open(protoFile)
+	defer reader.Close()
+	parser := proto.NewParser(reader)
+	definition, err := parser.Parse()
+	if err != nil {
+		return nil
+	}
+
+	// extract the Messages as DataSchema
+	proto.Walk(definition,
+		proto.WithService(b.HandleService),
+		proto.WithMessage(b.HandleMessage))
+
+	// translate the RPC functions into Interaction Affordances
+	proto.Walk(definition,
+		proto.WithRPC(b.HandleRPC))
+
+	// serialize the TD to JSONLD
+	tdBytes, _ := json.Marshal(b.td)
+	f, err := os.Create(tdFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.Write(tdBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/prototd/README.md
+++ b/cmd/prototd/README.md
@@ -1,0 +1,43 @@
+# prototd
+A simple command line tool to generate a Thing Description from Protocol Buffers
+
+prototd takes one `.proto` file that contains one gRPC serivce with RPCs (currently only Unary RPCs) and the Messages used by them, and generate a W3C Web of Things Thing Description for the gRPC service that a HTTP2 client can consume.
+
+Following [the document about an imlementation of gRPC](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) carried over HTTP2 framing, we generate the corresponding [Interaction Affordances](https://www.w3.org/TR/wot-thing-description/#interactionaffordance) to the RPCs exposed by the gRPC service.
+
+## Mapping from Protocol Buffers to Thing Description
+
+protod takes the IP address and the port where the gRPC service is hosted to provide the target IRI in the [`forms`](https://www.w3.org/TR/wot-thing-description/#form).
+
+protod implements a policy to classify RPCs into one of the Interaction Affordances: Property, Action, and Event.
+
+This classification assumes that the provided protobuf file is conformal [the Protocol Buffers Style Guide](https://developers.google.com/protocol-buffers/docs/style) as well as other generic naming conventions, such as `GetPropertyName` for accessing a property `PropertyName`.
+
+For encoding unary RPCs, those functions which do not take input parameters are assumed to take an `Empty` message such as:
+```proto
+message Empty {
+}
+```
+
+The policy is encoded in [the handlers](https://pkg.go.dev/github.com/emicklei/proto@v1.9.2#Handler) by parsing the protobuf file with [`github.com/emicklei/proto`](https://github.com/emicklei/proto).
+
+prototd uses the `ThingDescription` type from [`github.com/linksmart/thing-directory/wot`](https://github.com/linksmart/thing-directory/blob/master/wot/thing_description.go) for JSON marshaller.
+
+## Usage
+
+```console
+NAME:
+   prototd - Translate ProtocolBuffers to ThingDescription
+
+USAGE:
+   prototd [global options] command [command options] [arguments...]
+
+COMMANDS:
+   help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --port value, -p value  The port for the gRPC service (default: 50051)
+   --ip value              The IP address for the gRPC serivce (default: "127.0.0.1")
+   --output FILE, -o FILE  Write the resulting Thing Description to FILE (default: "td.jsonld")
+   --help, -h              show help (default: false)
+```

--- a/cmd/prototd/main.go
+++ b/cmd/prototd/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"errors"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/Interactions-HSG/grpcwot"
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	app := &cli.App{
+		Flags: []cli.Flag{
+			&cli.IntFlag{
+				Name:    "port",
+				Aliases: []string{"p"},
+				Value:   50051,
+				Usage:   "The port for the gRPC service",
+			},
+			&cli.StringFlag{
+				Name:  "ip",
+				Value: "127.0.0.1",
+				Usage: "The IP address for the gRPC serivce",
+			},
+			&cli.StringFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Value:   "td.jsonld",
+				Usage:   "Write the resulting Thing Description to `FILE`",
+			},
+		},
+		Name:  "prototd",
+		Usage: "Translate ProtocolBuffers to ThingDescription",
+		Action: func(c *cli.Context) error {
+			protoFile := c.Args().Get(0)
+			if !strings.HasSuffix(protoFile, ".proto") {
+				return errors.New("The input file must be a .proto file")
+			} else if _, err := os.Stat(protoFile); errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			return grpcwot.GenerateTDfromProtoBuf(protoFile, c.String("output"), c.String("ip"), c.Int("port"))
+		},
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,20 @@
+module grpcwot
+
+go 1.17
+
+replace github.com/Interactions-HSG/grpcwot => ./
+
+require (
+	github.com/Interactions-HSG/grpcwot v0.0.0-00010101000000-000000000000
+	github.com/emicklei/proto v1.9.2
+	github.com/linksmart/thing-directory v1.0.0-beta.22
+	github.com/urfave/cli/v2 v2.4.0
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+)

--- a/pkg/protofmt/reflector.go
+++ b/pkg/protofmt/reflector.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Ernest Micklei
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package protofmt
+
+import "github.com/emicklei/proto"
+
+// reflector is a Visitor that can tell the short type name of a Visitee.
+type reflector struct {
+	name string
+}
+
+// sole instance of reflector
+var namer = new(reflector)
+
+func (r *reflector) VisitMessage(m *proto.Message)         { r.name = "Message" }
+func (r *reflector) VisitService(v *proto.Service)         { r.name = "Service" }
+func (r *reflector) VisitSyntax(s *proto.Syntax)           { r.name = "Syntax" }
+func (r *reflector) VisitPackage(p *proto.Package)         { r.name = "Package" }
+func (r *reflector) VisitOption(o *proto.Option)           { r.name = "Option" }
+func (r *reflector) VisitImport(i *proto.Import)           { r.name = "Import" }
+func (r *reflector) VisitNormalField(i *proto.NormalField) { r.name = "NormalField" }
+func (r *reflector) VisitEnumField(i *proto.EnumField)     { r.name = "EnumField" }
+func (r *reflector) VisitEnum(e *proto.Enum)               { r.name = "Enum" }
+func (r *reflector) VisitComment(e *proto.Comment)         { r.name = "Comment" }
+func (r *reflector) VisitOneof(o *proto.Oneof)             { r.name = "Oneof" }
+func (r *reflector) VisitOneofField(o *proto.OneOfField)   { r.name = "OneOfField" }
+func (r *reflector) VisitReserved(rs *proto.Reserved)      { r.name = "Reserved" }
+func (r *reflector) VisitRPC(rpc *proto.RPC)               { r.name = "RPC" }
+func (r *reflector) VisitMapField(f *proto.MapField)       { r.name = "NormalField" } // handle as
+func (r *reflector) VisitGroup(g *proto.Group)             { r.name = "Group" }
+func (r *reflector) VisitExtensions(e *proto.Extensions)   { r.name = "Extensions" }
+
+// NameOfVisitee returns the short type name of a Visitee.
+func NameOfVisitee(e proto.Visitee) string {
+	e.Accept(namer)
+	return namer.name
+}


### PR DESCRIPTION
As reviewing #4, I figured that it would better streamline several requirements and the design plan if I open a separate PR.

I attempted to describe a very brief overview of the proposed command line tool protod: https://github.com/Interactions-HSG/grpcwot/compare/feat/scaffolding?expand=1#diff-2744de82f6684658f2558ab97874a78842cf96458fe78c8442eeb6834a36e06e

With this proto type, you can generate `td.jsonld` by feeding `xapi.proto`:
```console
% prototd xapi.proto
% cat td.jsonld|jq
{
  "@context": null,
  "title": "XAPI",
  "created": "0001-01-01T00:00:00Z",
  "modified": "0001-01-01T00:00:00Z",
  "actions": {
    "Disconnect": {
      "forms": [
        {
          "op": [
            "writeproperty"
          ],
          "href": "http://127.0.0.1:50051/XAPI/Disconnect",
          "contentType": "application/grpc+proto"
        }
      ],
      "input": {
        "type": "object"
      },
      "output": {
        "type": "object"
      },
      "safe": false,
      "idempotent": false
    },
  ...
  },
  "security": null,
  "securityDefinitions": null
}
```

This PR closes #3, closes #5, and closes #10