### PR TITLE
Supporting all scalar field types

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -82,15 +82,23 @@ func (b *builder) HandleMessage(m *proto.Message) {
 }
 
 func fieldToDataSchema(f *proto.Field) wot.DataSchema {
+	return wot.DataSchema{DataType: determineJsonTypeForField(f)}
+}
+
+// determineJsonTypeForField is a helper function to convert datatypes used in proto files into data types used in
+// json format.
+func determineJsonTypeForField(f *proto.Field) string {
 	switch f.Type {
+	case "double", "float":
+		return "number"
+	case "int32", "int64", "uint32", "uint64", "sint32", "sint64", "fixed32", "fixed64", "sfixed32", "sfixed64":
+		return "integer"
 	case "bool":
-		return wot.DataSchema{DataType: "boolean"}
-	case "float":
-		return wot.DataSchema{DataType: "number"}
-	case "int32":
-		return wot.DataSchema{DataType: "integer"}
+		return "boolean"
+	case "string", "bytes":
+		return "string"
 	default:
-		return wot.DataSchema{DataType: "string"}
+		return "object"
 	}
 }
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,50 @@
+package grpcwot
+
+import (
+	"fmt"
+	"github.com/emicklei/proto"
+	"io/ioutil"
+	"os"
+)
+
+type unmarshalExpected func([]byte) error
+
+// General helper functions
+
+func parseProtoFileToBuilder(protoFile string) (b *builder) {
+	b = newBuilder("", 0)
+
+	// parse the protoFile with the emicklei/proto
+	reader, _ := os.Open(protoFile)
+	defer reader.Close()
+	parser := proto.NewParser(reader)
+	definition, err := parser.Parse()
+	if err != nil {
+		return nil
+	}
+
+	proto.Walk(definition,
+		proto.WithMessage(b.HandleMessage))
+
+	return b
+}
+
+func unmarshalExpectedFile(expectedFile string, fn unmarshalExpected) {
+	jsonFile, err := os.Open(expectedFile)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer func(jsonFile *os.File) {
+		jsonFile.Close()
+	}(jsonFile)
+
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return
+	}
+	err = fn(byteValue)
+	if err != nil {
+		return
+	}
+}

--- a/builder_test.go
+++ b/builder_test.go
@@ -12,6 +12,17 @@ import (
 
 type unmarshalExpected func([]byte) error
 
+// Message parsing tests - scalar field types
+// Proto files as input files are provided under testFiles/testScalarFieldTypes/proto
+// The desired structure of data schemas are provided under testFiles/testScalarFieldTypes/jsonLD
+
+// The input file scalarFieldTypeMessage provides only one message with fields of scalar value types
+// Every scalar value type listed for proto3 (https://developers.google.com/protocol-buffers/docs/proto3#scalar) is included with one field
+// The test expects, that all scalar value types are converted into the corresponding json value type according to the table provided above
+func TestMessageParserStandardMessage(t *testing.T) {
+	MessageParserTestHelper(t, "scalarFieldTypeMessage", "testFiles/testScalarFieldTypes")
+}
+
 // Helper functions for message testing
 
 func MessageParserTestHelper(t *testing.T, f string, dir string) {

--- a/testFiles/testScalarFieldTypes/json/scalarFieldTypeMessage.json
+++ b/testFiles/testScalarFieldTypes/json/scalarFieldTypeMessage.json
@@ -1,0 +1,52 @@
+{
+  "Test": {
+    "type": "object",
+    "properties": {
+      "testBool": {
+        "type": "boolean"
+      },
+      "testBytes": {
+        "type": "string"
+      },
+      "testDouble": {
+        "type": "number"
+      },
+      "testFixed32": {
+        "type": "integer"
+      },
+      "testFixed64": {
+        "type": "integer"
+      },
+      "testFloat": {
+        "type": "number"
+      },
+      "testInt32": {
+        "type": "integer"
+      },
+      "testInt64": {
+        "type": "integer"
+      },
+      "testSFixed32": {
+        "type": "integer"
+      },
+      "testSFixed64": {
+        "type": "integer"
+      },
+      "testSInt32": {
+        "type": "integer"
+      },
+      "testSInt64": {
+        "type": "integer"
+      },
+      "testString": {
+        "type": "string"
+      },
+      "testUInt32": {
+        "type": "integer"
+      },
+      "testUInt64": {
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/testFiles/testScalarFieldTypes/protos/scalarFieldTypeMessage.proto
+++ b/testFiles/testScalarFieldTypes/protos/scalarFieldTypeMessage.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+message Test {
+  // number
+  double testDouble = 1;
+  float testFloat = 2;
+  // integer
+  int32 testInt32 = 3;
+  int64 testInt64 = 4;
+  uint32 testUInt32 = 5;
+  uint64 testUInt64 = 6;
+  sint32 testSInt32 = 7;
+  sint64 testSInt64 = 8;
+  fixed32 testFixed32 = 9;
+  fixed64 testFixed64 = 10;
+  sfixed32 testSFixed32 = 11;
+  sfixed64 testSFixed64 = 12;
+  // bool
+  bool testBool = 13;
+  // string
+  string testString = 14;
+  bytes testBytes = 15;
+}


### PR DESCRIPTION
According to #15, this PR should add the ability to deal with all scalar value field types.
I also added tests with helper methods for the builder.go file to test if all types are converted to the correct JSON representation.
The helper methods can also be helpful for the following features, as they provide the ability to create the actual from the builder and read in an expected from a file.

This PR closes #15.