### PR TITLE
Affordance Classification

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,9 +1,11 @@
 package grpcwot
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/emicklei/proto"
 	"github.com/linksmart/thing-directory/wot"
@@ -12,16 +14,28 @@ import (
 type builder struct {
 	td   wot.ThingDescription
 	dsb  *dataSchemaBuilder
+	iab  *interactionAffordanceBuilder
 	ip   string
 	port int
+	ac   map[string]affClassConfig
+}
+
+type affClassConfig struct {
+	AffClass string
+	Name     string `json:"Name,omitempty"`
 }
 
 func newBuilder(ip string, port int, dsb *dataSchemaBuilder) *builder {
 	return &builder{
-		td:   wot.ThingDescription{},
+		td: wot.ThingDescription{
+			Properties: map[string]wot.PropertyAffordance{},
+			Actions:    map[string]wot.ActionAffordance{},
+			Events:     map[string]wot.EventAffordance{},
+		},
 		dsb:  dsb,
 		ip:   ip,
 		port: port,
+		ac:   map[string]affClassConfig{},
 	}
 }
 
@@ -35,25 +49,219 @@ func (b *builder) HandleService(s *proto.Service) {
 	b.td.Title = s.Name
 }
 
-// HandleRPC constructs Interaction Affordances with prefetched DataSchema
-func (b *builder) HandleRPC(r *proto.RPC) {
-	// TODO: affordance classification should happen here
-	// putting all RPC to Actions for now
-	if b.td.Actions == nil {
-		b.td.Actions = map[string]wot.ActionAffordance{}
-	}
-	affordance := wot.ActionAffordance{}
-	affordance.Input = *b.dsb.ds[r.RequestType]
-	affordance.Output = *b.dsb.ds[r.ReturnsType]
-	affordance.Forms = []wot.Form{
+// getForms is a helper method to build the forms
+func (b *builder) getForms(n string, ops []string) []wot.Form {
+	return []wot.Form{
 		{
-			Href:        b.GetIRI(r.Name),
+			Href:        b.GetIRI(n),
 			ContentType: "application/grpc+proto",
-			Op:          []string{"writeproperty"},
+			Op:          ops,
 		},
 	}
+}
 
-	b.td.Actions[r.Name] = affordance
+// saveToAffClass is a helper function to save affordances in the affordance classification so they could be
+// transformed into json and be reused for further builds
+func (b *builder) saveToAffClass(k, n, affClass string) {
+	if k == n {
+		b.ac[k] = affClassConfig{
+			AffClass: affClass,
+		}
+	} else {
+		b.ac[k] = affClassConfig{
+			Name:     n,
+			AffClass: affClass,
+		}
+	}
+}
+
+// saveProperty converts and saves a RPC function to a Property Affordance in the TD
+func (b *builder) saveProperty(p combinedProperties) {
+	affordance := wot.PropertyAffordance{}
+	var ops []string
+	switch p.category {
+	case 0:
+		b.saveToAffClass(p.getProp.name, p.name, "property")
+		affordance.DataSchema = *p.getProp.res
+		ops = []string{"readproperty"}
+	case 1:
+		b.saveToAffClass(p.setProp.name, p.name, "property")
+		affordance.DataSchema = *p.setProp.req
+		ops = []string{"writeproperty"}
+	case 2:
+		b.saveToAffClass(p.getProp.name, p.name, "property")
+		b.saveToAffClass(p.setProp.name, p.name, "property")
+		affordance.DataSchema = *p.getProp.res
+		ops = []string{"readproperty", "writeproperty"}
+	default:
+		return
+	}
+
+	affordance.Forms = b.getForms(p.name, ops)
+	b.td.Properties[p.name] = affordance
+}
+
+// saveAction converts and saves a RPC function to an Action Affordance in the TD
+func (b *builder) saveAction(r affs) {
+	affordance := wot.ActionAffordance{}
+	affordance.Input = *r.req
+	affordance.Output = *r.res
+	affordance.Forms = b.getForms(r.name, []string{})
+	b.td.Actions[r.name] = affordance
+
+	b.saveToAffClass(r.name, r.name, "action")
+}
+
+// saveEvent converts and saves a RPC function to an Event Affordance in the TD
+func (b *builder) saveEvent(r affs) {
+	affordance := wot.EventAffordance{}
+	affordance.Data = *r.res
+	affordance.Forms = b.getForms(r.name, []string{})
+	b.td.Events[r.name] = affordance
+
+	b.saveToAffClass(r.name, r.name, "event")
+}
+
+// readInput is a helper function to read in input from the user
+func readInput(reader *bufio.Reader, s, k string, v []string) string {
+	allowedInputs := []string{"", "a", "p", "e"}
+	for {
+		if len(v) == 1 {
+			fmt.Printf("%s '%s' with RPC function '%s'\n", s, k, v[0])
+		} else {
+			fmt.Printf("%s '%s' with RPC functions '%s' and '%s'\n", s, k, v[0], v[1])
+		}
+		fmt.Print("->")
+		t, _ := reader.ReadString('\n')
+		t = strings.TrimSpace(t)
+		if contains(allowedInputs, t) {
+			return t
+		}
+	}
+}
+
+// categorizeAffordancesWithUserInput asks the user for validation of the made classification decisions and saves the
+// affordances to the TD
+func (b *builder) categorizeAffordancesWithUserInput() {
+	fmt.Println("The following interaction affordances are already classified according to specific criterias." +
+		"If you want to change the classification for a specific affordance please enter")
+	fmt.Println("- (p) for property")
+	fmt.Println("- (a) for action or")
+	fmt.Println("- (e) for event")
+	fmt.Println("If the classification is already correct, press enter.")
+
+	reader := bufio.NewReader(os.Stdin)
+
+	if len(b.iab.affC.combinedProp) != 0 {
+		fmt.Println("The following were considered as properties: ")
+	}
+	for _, v := range b.iab.affC.combinedProp {
+		t := readInput(reader, "Property", v.name, []string{v.getProp.name, v.setProp.name})
+		switch t {
+		case "":
+			fallthrough
+		case "p":
+			b.saveProperty(v)
+		case "a":
+			switch v.category {
+			case 2:
+				fmt.Println("Should only the setter become an action (set) or both (both)?")
+				fmt.Print("->")
+				t, _ := reader.ReadString('\n')
+				t = strings.TrimSpace(t)
+				if t == "set" {
+					b.saveAction(v.setProp)
+					v.setProp = affs{}
+					v.category = 0
+					b.saveProperty(v)
+				} else if t == "both" {
+					b.saveAction(v.getProp)
+					b.saveAction(v.setProp)
+				}
+			case 1:
+				b.saveAction(v.setProp)
+			case 0:
+				b.saveAction(v.getProp)
+			}
+		case "e":
+			if v.category == 2 {
+				v.category = 1
+				b.saveProperty(v)
+			}
+			b.saveEvent(v.getProp)
+		}
+	}
+	if len(b.iab.affC.action) != 0 {
+		fmt.Println("The following were considered as actions: ")
+	}
+	for _, v := range b.iab.affC.action {
+		t := readInput(reader, "Action", v.name, []string{v.name})
+		switch t {
+		case "":
+			fallthrough
+		case "a":
+			b.saveAction(v)
+		case "p":
+			if v.req.Type == "" {
+				b.saveProperty(combinedProperties{
+					name:     v.name,
+					getProp:  v,
+					category: 0,
+				})
+			} else {
+				b.saveProperty(combinedProperties{
+					name:     v.name,
+					setProp:  v,
+					category: 1,
+				})
+			}
+		case "e":
+			b.saveEvent(v)
+		}
+	}
+	if len(b.iab.affC.event) != 0 {
+		fmt.Println("The following were considered as events: ")
+	}
+	for _, v := range b.iab.affC.event {
+		t := readInput(reader, "Event", v.name, []string{v.name})
+		switch t {
+		case "":
+			fallthrough
+		case "e":
+			b.saveEvent(v)
+		case "p":
+			b.saveProperty(combinedProperties{
+				name:     v.name,
+				getProp:  v,
+				category: 0,
+			})
+		case "a":
+			b.saveAction(v)
+		}
+	}
+}
+
+//saveAfterConfigRPC Saves the affordances to the TD with the classification derived from the vonfig
+func (b *builder) saveAfterConfigRPC() {
+	for _, v := range b.iab.affC.combinedProp {
+		b.saveProperty(v)
+	}
+	for _, v := range b.iab.affC.action {
+		b.saveAction(v)
+	}
+	for _, v := range b.iab.affC.event {
+		b.saveEvent(v)
+	}
+}
+
+// contains, helper function do determine if a slice of type string contains the string s
+func contains(a []string, s string) bool {
+	for _, v := range a {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 // GenerateTDfromProtoBuf parses `protoFile` to generate `tdFile`
@@ -77,14 +285,15 @@ func GenerateTDfromProtoBuf(protoFile, tdFile, ip string, port int) error { // p
 
 	// translate the RPC functions into Interaction Affordances
 	proto.Walk(definition,
-		proto.WithService(b.HandleService),
-		proto.WithRPC(b.HandleRPC))
+		proto.WithService(b.HandleService))
 
-	iab, err := generateInteractionAffordances(definition, dsb)
+	b.iab, err = generateInteractionAffordances(definition, dsb)
 
-	if iab == nil {
+	if b.iab == nil {
 		return err
 	}
+
+	b.categorizeAffordancesWithUserInput()
 
 	// serialize the TD to JSONLD
 	tdBytes, _ := json.Marshal(b.td)

--- a/builder.go
+++ b/builder.go
@@ -57,9 +57,7 @@ func (b *builder) HandleRPC(r *proto.RPC) {
 }
 
 // GenerateTDfromProtoBuf parses `protoFile` to generate `tdFile`
-func GenerateTDfromProtoBuf(protoFile, tdFile, ip string, port int) error {
-
-	// parse the protoFile with the emicklei/proto
+func GenerateTDfromProtoBuf(protoFile, tdFile, ip string, port int) error { // parse the protoFile with the emicklei/proto
 	reader, _ := os.Open(protoFile)
 	defer reader.Close()
 	parser := proto.NewParser(reader)
@@ -81,6 +79,12 @@ func GenerateTDfromProtoBuf(protoFile, tdFile, ip string, port int) error {
 	proto.Walk(definition,
 		proto.WithService(b.HandleService),
 		proto.WithRPC(b.HandleRPC))
+
+	iab, err := generateInteractionAffordances(definition, dsb)
+
+	if iab == nil {
+		return err
+	}
 
 	// serialize the TD to JSONLD
 	tdBytes, _ := json.Marshal(b.td)

--- a/interaction_affordance_builder.go
+++ b/interaction_affordance_builder.go
@@ -29,9 +29,10 @@ type affClasses struct {
 }
 
 type combinedProperties struct {
-	name    string
-	getProp affs
-	setProp affs
+	name     string
+	getProp  affs
+	setProp  affs
+	category int // 0: read only; 1: write only; 2: readwrite
 }
 
 type affs struct {
@@ -127,17 +128,30 @@ func (b *interactionAffordanceBuilder) checkPropertyCombination(p affs, s1, s2 s
 		}
 		if isGet {
 			b.affC.combinedProp = append(b.affC.combinedProp, combinedProperties{
-				name:    propName,
-				getProp: p,
-				setProp: cand,
+				name:     propName,
+				getProp:  p,
+				setProp:  cand,
+				category: getPropertyCategory(p.name, cand.name),
 			})
 		} else {
 			b.affC.combinedProp = append(b.affC.combinedProp, combinedProperties{
-				name:    propName,
-				getProp: cand,
-				setProp: p,
+				name:     propName,
+				getProp:  cand,
+				setProp:  p,
+				category: getPropertyCategory(cand.name, p.name),
 			})
 		}
+	}
+}
+
+func getPropertyCategory(get, set string) int {
+	switch {
+	case set == "":
+		return 0
+	case get == "":
+		return 1
+	default:
+		return 2
 	}
 }
 
@@ -220,6 +234,8 @@ func generateInteractionAffordances(protoFile *proto.Proto, dsb *dataSchemaBuild
 	}
 
 	b.categorizeRPCs()
+
+	b.groupProperties()
 
 	return b, nil
 }

--- a/interaction_affordance_builder.go
+++ b/interaction_affordance_builder.go
@@ -1,0 +1,70 @@
+package grpcwot
+
+import (
+	"errors"
+	"github.com/emicklei/proto"
+	"github.com/linksmart/thing-directory/wot"
+)
+
+type interactionAffordanceBuilder struct {
+	rpcs []*proto.RPC
+	affs map[string]affs
+	dsb  *dataSchemaBuilder
+}
+
+type affs struct {
+	req *wot.DataSchema
+	res *wot.DataSchema
+}
+
+func newInteractionAffordanceBuilder(dsb *dataSchemaBuilder) *interactionAffordanceBuilder {
+	return &interactionAffordanceBuilder{
+		[]*proto.RPC{},
+		map[string]affs{},
+		dsb,
+	}
+}
+
+func (b *interactionAffordanceBuilder) HandleRPC(r *proto.RPC) {
+	b.rpcs = append(b.rpcs, r)
+}
+
+func (b *interactionAffordanceBuilder) conformRPCs() error {
+	b.affs = map[string]affs{}
+	for _, v := range b.rpcs {
+		if _, found := b.affs[v.Name]; found {
+			return errors.New("Duplicate RPC name found in proto file for RPC name " + v.Name)
+		}
+		req, found := b.dsb.ds[v.RequestType]
+		if !found {
+			return errors.New("Not able to determine message for request type " + v.RequestType + " in RPC " + v.Name)
+		}
+		res, found := b.dsb.ds[v.ReturnsType]
+		if !found {
+			return errors.New("Not able to determine message for return type " + v.ReturnsType + " in RPC " + v.Name)
+		}
+		b.affs[v.Name] = affs{
+			req,
+			res,
+		}
+	}
+	return nil
+}
+
+func (b *interactionAffordanceBuilder) prefilterRPCs() {
+
+}
+
+func generateInteractionAffordances(protoFile *proto.Proto, dsb *dataSchemaBuilder) (*interactionAffordanceBuilder, error) {
+	b := newInteractionAffordanceBuilder(dsb)
+
+	proto.Walk(protoFile,
+		proto.WithRPC(b.HandleRPC))
+
+	err := b.conformRPCs()
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}

--- a/interaction_affordance_builder_test.go
+++ b/interaction_affordance_builder_test.go
@@ -1,0 +1,164 @@
+package grpcwot
+
+import (
+	"errors"
+	"github.com/emicklei/proto"
+	"github.com/linksmart/thing-directory/wot"
+	"testing"
+)
+
+var inMessages = []map[string]*wot.DataSchema{
+	{
+		"TestM1": {},
+		"TestM2": {},
+	},
+	{
+		"TestM1":         {},
+		"TestM1.TestIM1": {},
+		"TestM2":         {},
+	},
+}
+
+var conformRPCTest = []struct {
+	inMessages map[string]*wot.DataSchema
+	inRPCs     []*proto.RPC
+	out        map[string]affs
+	err        error
+}{
+	{
+		inMessages[0],
+		[]*proto.RPC{
+			{
+				Name:        "TestRPC1",
+				RequestType: "TestM1",
+				ReturnsType: "TestM2",
+			},
+		},
+		map[string]affs{
+			"TestRPC1": {
+				req: inMessages[0]["TestM1"],
+				res: inMessages[0]["TestM2"],
+			},
+		},
+		nil,
+	},
+	{
+		inMessages[1],
+		[]*proto.RPC{
+			{
+				Name:        "TestRPC2",
+				RequestType: "TestM1.TestIM1",
+				ReturnsType: "TestM2",
+			},
+		},
+		map[string]affs{
+			"TestRPC2": {
+				req: inMessages[1]["TestM1.TestIM1"],
+				res: inMessages[1]["TestM2"],
+			},
+		},
+		nil,
+	},
+	{
+		inMessages[0],
+		[]*proto.RPC{
+			{
+				Name:        "TestRPC3",
+				RequestType: "TestM1",
+				ReturnsType: "TestM2",
+			},
+			{
+				Name:        "TestRPC4",
+				RequestType: "TestM2",
+				ReturnsType: "TestM1",
+			},
+		},
+		map[string]affs{
+			"TestRPC3": {
+				req: inMessages[0]["TestM1"],
+				res: inMessages[0]["TestM2"],
+			},
+			"TestRPC4": {
+				req: inMessages[0]["TestM2"],
+				res: inMessages[0]["TestM1"],
+			},
+		},
+		nil,
+	},
+	{
+		map[string]*wot.DataSchema{
+			"T": {},
+		},
+		[]*proto.RPC{
+			{
+				Name:        "TestRPCError1",
+				RequestType: "T",
+				ReturnsType: "T",
+			},
+			{
+				Name:        "TestRPCError1",
+				RequestType: "T",
+				ReturnsType: "T",
+			},
+		},
+		map[string]affs{},
+		errors.New("Duplicate RPC name found in proto file for RPC name TestRPCError1"),
+	},
+	{
+		map[string]*wot.DataSchema{
+			"T": {},
+		},
+		[]*proto.RPC{
+			{
+				Name:        "TestRPCError2",
+				RequestType: "E",
+				ReturnsType: "T",
+			},
+		},
+		map[string]affs{},
+		errors.New("Not able to determine message for request type E in RPC TestRPCError2"),
+	},
+	{
+		map[string]*wot.DataSchema{
+			"T": {},
+		},
+		[]*proto.RPC{
+			{
+				Name:        "TestRPCError3",
+				RequestType: "T",
+				ReturnsType: "E",
+			},
+		},
+		map[string]affs{},
+		errors.New("Not able to determine message for return type E in RPC TestRPCError3"),
+	},
+}
+
+func TestConformRPC(t *testing.T) {
+	for _, v := range conformRPCTest {
+		dsb := &dataSchemaBuilder{
+			ds: v.inMessages,
+		}
+		iab := &interactionAffordanceBuilder{
+			rpcs: v.inRPCs,
+			dsb:  dsb,
+		}
+		err := iab.conformRPCs()
+		if v.err != nil {
+			if err == nil {
+				t.Errorf("Expected the error %v,\n but nothing was raised", v.err.Error())
+			} else if err.Error() != v.err.Error() {
+				t.Errorf("Wrong error message:\n Expected: %v\n but actual is: %v\n", v.err.Error(), err.Error())
+			}
+		} else {
+			for k, v := range v.out {
+				if iab.affs[k].req != v.req {
+					t.Errorf("Expected the request type %v,\n but got %v\n for RPC %v", v.req, iab.affs[k].req, k)
+				}
+				if iab.affs[k].res != v.res {
+					t.Errorf("Expected the return type %v,\n but got %v\n for RPC %v", v.res, iab.affs[k].res, k)
+				}
+			}
+		}
+	}
+}

--- a/interaction_affordance_builder_test.go
+++ b/interaction_affordance_builder_test.go
@@ -162,3 +162,176 @@ func TestConformRPC(t *testing.T) {
 		}
 	}
 }
+
+var categorizeRPCTestAffordances = map[string]affs{
+	"SimpleTest": {
+		name: "SimpleTest",
+		req:  &wot.DataSchema{},
+		res:  &wot.DataSchema{},
+	},
+	"GetTest": {
+		name: "GetTest",
+		req:  &wot.DataSchema{},
+		res:  &wot.DataSchema{},
+	},
+	"GetTest2": {
+		name: "GetTest2",
+		req:  &wot.DataSchema{},
+		res:  &wot.DataSchema{},
+	},
+	"SetTest": {
+		name: "SetTest",
+		req:  &wot.DataSchema{},
+		res:  &wot.DataSchema{},
+	},
+	"TestWithReturn": {
+		name: "TestWithReturn",
+		req:  &wot.DataSchema{},
+		res: &wot.DataSchema{
+			DataType: "object",
+			ObjectSchema: &wot.ObjectSchema{
+				Properties: map[string]wot.DataSchema{
+					"Test": {},
+				},
+			},
+		},
+	},
+	"TestWithRequest": {
+		name: "TestWithRequest",
+		req: &wot.DataSchema{
+			DataType: "object",
+			ObjectSchema: &wot.ObjectSchema{
+				Properties: map[string]wot.DataSchema{
+					"Test": {},
+				},
+			},
+		},
+		res: &wot.DataSchema{},
+	},
+	"TestWithRequestAndReturn": {
+		name: "TestWithRequestAndReturn",
+		req: &wot.DataSchema{
+			DataType: "object",
+			ObjectSchema: &wot.ObjectSchema{
+				Properties: map[string]wot.DataSchema{
+					"Test": {},
+				},
+			},
+		},
+		res: &wot.DataSchema{
+			DataType: "object",
+			ObjectSchema: &wot.ObjectSchema{
+				Properties: map[string]wot.DataSchema{
+					"Test": {},
+				},
+			},
+		},
+	},
+}
+
+var categorizeRPCTest = []struct {
+	inIab interactionAffordanceBuilder
+	out   affClasses
+}{
+	{
+		interactionAffordanceBuilder{
+			affs: map[string]affs{
+				"SimpleTest": categorizeRPCTestAffordances["SimpleTest"],
+			},
+			cats: catProps{
+				prop:   func(a affs) bool { return true },
+				action: func(a affs) bool { return false },
+				event:  func(a affs) bool { return false },
+			},
+		},
+		affClasses{
+			prop:   []affs{categorizeRPCTestAffordances["SimpleTest"]},
+			action: []affs{},
+			event:  []affs{},
+		},
+	},
+	{
+		interactionAffordanceBuilder{
+			affs: map[string]affs{
+				"SimpleTest": categorizeRPCTestAffordances["SimpleTest"],
+				"GetTest":    categorizeRPCTestAffordances["GetTest"],
+				"SetTest":    categorizeRPCTestAffordances["SetTest"],
+			},
+			cats: catProps{
+				prop:   or(startsWithGet, startsWithSet),
+				action: func(a affs) bool { return true },
+				event:  func(a affs) bool { return true },
+			},
+		},
+		affClasses{
+			prop:   []affs{categorizeRPCTestAffordances["GetTest"], categorizeRPCTestAffordances["SetTest"]},
+			action: []affs{},
+			event:  []affs{categorizeRPCTestAffordances["SimpleTest"]},
+		},
+	},
+	{
+		interactionAffordanceBuilder{
+			affs: map[string]affs{
+				"SimpleTest": categorizeRPCTestAffordances["SimpleTest"],
+				"GetTest":    categorizeRPCTestAffordances["GetTest"],
+				"SetTest":    categorizeRPCTestAffordances["SetTest"],
+			},
+			cats: catProps{
+				prop:   or(startsWithGet, startsWithSet),
+				action: func(a affs) bool { return true },
+				event:  func(a affs) bool { return true },
+			},
+		},
+		affClasses{
+			prop:   []affs{categorizeRPCTestAffordances["GetTest"], categorizeRPCTestAffordances["SetTest"]},
+			action: []affs{},
+			event:  []affs{categorizeRPCTestAffordances["SimpleTest"]},
+		},
+	},
+	{
+		interactionAffordanceBuilder{
+			affs: map[string]affs{
+				"TestWithRequest":          categorizeRPCTestAffordances["TestWithRequest"],
+				"TestWithReturn":           categorizeRPCTestAffordances["TestWithReturn"],
+				"TestWithRequestAndReturn": categorizeRPCTestAffordances["TestWithRequestAndReturn"],
+			},
+			cats: catProps{
+				prop:   and(hasRequestType, hasReturnType),
+				action: hasReturnType,
+				event:  not(hasRequestType),
+			},
+		},
+		affClasses{
+			prop:   []affs{categorizeRPCTestAffordances["TestWithRequestAndReturn"]},
+			action: []affs{categorizeRPCTestAffordances["TestWithRequest"]},
+			event:  []affs{categorizeRPCTestAffordances["TestWithReturn"]},
+		},
+	},
+}
+
+func TestCategorizeRPC(t *testing.T) {
+	for _, v := range categorizeRPCTest {
+		v.inIab.categorizeRPCs()
+		equals(v.out.prop, v.inIab.affC.prop, t)
+		equals(v.out.action, v.inIab.affC.action, t)
+		equals(v.out.event, v.inIab.affC.event, t)
+	}
+}
+
+func equals(a1 []affs, a2 []affs, t *testing.T) {
+	if len(a1) != len(a2) {
+		t.Errorf("The length differs for the provided affordances.\n Expected %v\n but got: %v\n", a1, a2)
+	} else {
+	l:
+		for k, v := range a1 {
+			if a2[k] != v {
+				for _, a := range a2 {
+					if v == a {
+						continue l
+					}
+				}
+				t.Errorf("One expected element was not found. \n Expected: %v\n but was not in: %v\n", v, a2)
+			}
+		}
+	}
+}

--- a/interaction_affordance_builder_test.go
+++ b/interaction_affordance_builder_test.go
@@ -440,9 +440,46 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:    "Test1",
-					getProp: combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
-					setProp: combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
+					name:     "Test1",
+					getProp:  combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
+					setProp:  combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
+					category: 2,
+				},
+			},
+		},
+	},
+	{
+		interactionAffordanceBuilder{
+			affC: affClasses{
+				prop: []affs{
+					combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
+				},
+			},
+		},
+		affClasses{
+			combinedProp: []combinedProperties{
+				{
+					name:     "Test1",
+					getProp:  combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
+					category: 0,
+				},
+			},
+		},
+	},
+	{
+		interactionAffordanceBuilder{
+			affC: affClasses{
+				prop: []affs{
+					combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
+				},
+			},
+		},
+		affClasses{
+			combinedProp: []combinedProperties{
+				{
+					name:     "Test1",
+					setProp:  combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
+					category: 1,
 				},
 			},
 		},
@@ -459,9 +496,10 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:    "Test1",
-					getProp: combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
-					setProp: combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
+					name:     "Test1",
+					getProp:  combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
+					setProp:  combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
+					category: 2,
 				},
 			},
 		},
@@ -478,8 +516,9 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:    "Test2",
-					getProp: combinePropertiesTestAffordances["GetTest2WithDifferentResAsSet"],
+					name:     "Test2",
+					getProp:  combinePropertiesTestAffordances["GetTest2WithDifferentResAsSet"],
+					category: 0,
 				},
 			},
 			action: []affs{
@@ -499,12 +538,14 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:    "Test3Get",
-					getProp: combinePropertiesTestAffordances["GetTest3WithDifferentNameAndDifferentReqRes"],
+					name:     "Test3Get",
+					getProp:  combinePropertiesTestAffordances["GetTest3WithDifferentNameAndDifferentReqRes"],
+					category: 0,
 				},
 				{
-					name:    "Test3Set",
-					setProp: combinePropertiesTestAffordances["SetTest3WithDifferentNameAndDifferentReqRes"],
+					name:     "Test3Set",
+					setProp:  combinePropertiesTestAffordances["SetTest3WithDifferentNameAndDifferentReqRes"],
+					category: 1,
 				},
 			},
 		},
@@ -538,5 +579,8 @@ func equalsCombinedPropsSlice(e []combinedProperties, a []combinedProperties, t 
 }
 
 func equalsCombinedProps(a combinedProperties, b combinedProperties) bool {
-	return a.setProp == b.setProp && a.getProp == b.getProp && a.name == b.name
+	return a.setProp == b.setProp &&
+		a.getProp == b.getProp &&
+		a.name == b.name &&
+		a.category == b.category
 }


### PR DESCRIPTION
Add logic to classify affordances. 
- An interaction affordance builder is added to handle the logic for RPC reading and affordance classification
- The builder combines RPCs with their request and response types derived from the data schema builder
- It then classifies them into property, action, or event by specific checkConditions. These conditions are functions types which can be handed over to the classification
- The standard classification relies on "Get" and "Set" prefixes on the RPCs' names for property classification, and for only a response type for event classifications. Action is the fallback category