### PR TITLE
Add Server to CLI

### DIFF
--- a/data_schema_builder.go
+++ b/data_schema_builder.go
@@ -11,7 +11,7 @@ import (
 type refMesTuple struct {
 	pm string // Parent message where the field of type message is included
 	t  string // Type of the field == name of the referenced message
-	n  string // Name of the field
+	n  string // name of the field
 }
 
 type dataSchemaBuilder struct {

--- a/interaction_affordance_builder.go
+++ b/interaction_affordance_builder.go
@@ -29,16 +29,16 @@ type affClasses struct {
 }
 
 type combinedProperties struct {
-	name     string
-	getProp  affs
-	setProp  affs
-	category int // 0: read only; 1: write only; 2: readwrite
+	Name     string
+	GetProp  affs
+	SetProp  affs
+	Category int // 0: read only; 1: write only; 2: readwrite
 }
 
 type affs struct {
-	name string
-	req  *wot.DataSchema
-	res  *wot.DataSchema
+	Name string
+	Req  *wot.DataSchema
+	Res  *wot.DataSchema
 }
 
 func newInteractionAffordanceBuilder(dsb *dataSchemaBuilder) *interactionAffordanceBuilder {
@@ -68,7 +68,7 @@ func (b *interactionAffordanceBuilder) conformRPCs() error {
 	b.affs = map[string]affs{}
 	for _, v := range b.rpcs {
 		if _, found := b.affs[v.Name]; found {
-			return errors.New("Duplicate RPC name found in proto file for RPC name " + v.Name)
+			return errors.New("Duplicate RPC name found in proto file for RPC Name " + v.Name)
 		}
 		req, found := b.dsb.ds[v.RequestType]
 		if !found {
@@ -100,18 +100,18 @@ func (b *interactionAffordanceBuilder) groupProperties() {
 }
 
 func (b *interactionAffordanceBuilder) checkPropertyCombination(p affs, s1, s2 string, isGet bool, empty affs) {
-	pName := strings.ToUpper(p.name)
+	pName := strings.ToUpper(p.Name)
 	if strings.HasPrefix(pName, s1) {
-		propName := p.name[3:]
+		propName := p.Name[3:]
 		var cand affs
 
 		for k, v := range b.affC.prop {
 			if v == empty {
 				continue
 			}
-			if strings.HasPrefix(strings.ToUpper(v.name), s2) && v.name[3:] == propName {
-				if (isGet && v.req == p.res) ||
-					(!isGet && v.res == p.req) {
+			if strings.HasPrefix(strings.ToUpper(v.Name), s2) && v.Name[3:] == propName {
+				if (isGet && v.Req == p.Res) ||
+					(!isGet && v.Res == p.Req) {
 					cand = v
 					b.affC.prop[k] = empty
 					break
@@ -128,17 +128,17 @@ func (b *interactionAffordanceBuilder) checkPropertyCombination(p affs, s1, s2 s
 		}
 		if isGet {
 			b.affC.combinedProp = append(b.affC.combinedProp, combinedProperties{
-				name:     propName,
-				getProp:  p,
-				setProp:  cand,
-				category: getPropertyCategory(p.name, cand.name),
+				Name:     propName,
+				GetProp:  p,
+				SetProp:  cand,
+				Category: getPropertyCategory(p.Name, cand.Name),
 			})
 		} else {
 			b.affC.combinedProp = append(b.affC.combinedProp, combinedProperties{
-				name:     propName,
-				getProp:  cand,
-				setProp:  p,
-				category: getPropertyCategory(cand.name, p.name),
+				Name:     propName,
+				GetProp:  cand,
+				SetProp:  p,
+				Category: getPropertyCategory(cand.Name, p.Name),
 			})
 		}
 	}
@@ -162,19 +162,19 @@ func defaultConfig(_ affs) bool {
 }
 
 func startsWithGetCaseInsensitive(a affs) bool {
-	return strings.HasPrefix(strings.ToUpper(a.name), "GET")
+	return strings.HasPrefix(strings.ToUpper(a.Name), "GET")
 }
 
 func startsWithSetCaseInsensitive(a affs) bool {
-	return strings.HasPrefix(strings.ToUpper(a.name), "SET")
+	return strings.HasPrefix(strings.ToUpper(a.Name), "SET")
 }
 
 func startsWithGet(a affs) bool {
-	return strings.HasPrefix(a.name, "Get")
+	return strings.HasPrefix(a.Name, "Get")
 }
 
 func startsWithSet(a affs) bool {
-	return strings.HasPrefix(a.name, "Set")
+	return strings.HasPrefix(a.Name, "Set")
 }
 
 func typeNotEmpty(t *wot.DataSchema) bool {
@@ -184,11 +184,11 @@ func typeNotEmpty(t *wot.DataSchema) bool {
 }
 
 func hasReturnType(a affs) bool {
-	return typeNotEmpty(a.res)
+	return typeNotEmpty(a.Res)
 }
 
 func hasRequestType(a affs) bool {
-	return typeNotEmpty(a.req)
+	return typeNotEmpty(a.Req)
 }
 
 func and(condition checkCondition, condition2 checkCondition) checkCondition {

--- a/interaction_affordance_builder_test.go
+++ b/interaction_affordance_builder_test.go
@@ -36,8 +36,8 @@ var conformRPCTest = []struct {
 		},
 		map[string]affs{
 			"TestRPC1": {
-				req: inMessages[0]["TestM1"],
-				res: inMessages[0]["TestM2"],
+				Req: inMessages[0]["TestM1"],
+				Res: inMessages[0]["TestM2"],
 			},
 		},
 		nil,
@@ -53,8 +53,8 @@ var conformRPCTest = []struct {
 		},
 		map[string]affs{
 			"TestRPC2": {
-				req: inMessages[1]["TestM1.TestIM1"],
-				res: inMessages[1]["TestM2"],
+				Req: inMessages[1]["TestM1.TestIM1"],
+				Res: inMessages[1]["TestM2"],
 			},
 		},
 		nil,
@@ -75,12 +75,12 @@ var conformRPCTest = []struct {
 		},
 		map[string]affs{
 			"TestRPC3": {
-				req: inMessages[0]["TestM1"],
-				res: inMessages[0]["TestM2"],
+				Req: inMessages[0]["TestM1"],
+				Res: inMessages[0]["TestM2"],
 			},
 			"TestRPC4": {
-				req: inMessages[0]["TestM2"],
-				res: inMessages[0]["TestM1"],
+				Req: inMessages[0]["TestM2"],
+				Res: inMessages[0]["TestM1"],
 			},
 		},
 		nil,
@@ -102,7 +102,7 @@ var conformRPCTest = []struct {
 			},
 		},
 		map[string]affs{},
-		errors.New("Duplicate RPC name found in proto file for RPC name TestRPCError1"),
+		errors.New("Duplicate RPC name found in proto file for RPC Name TestRPCError1"),
 	},
 	{
 		map[string]*wot.DataSchema{
@@ -152,11 +152,11 @@ func TestConformRPC(t *testing.T) {
 			}
 		} else {
 			for k, v := range v.out {
-				if iab.affs[k].req != v.req {
-					t.Errorf("Expected the request type %v,\n but got %v\n for RPC %v", v.req, iab.affs[k].req, k)
+				if iab.affs[k].Req != v.Req {
+					t.Errorf("Expected the request type %v,\n but got %v\n for RPC %v", v.Req, iab.affs[k].Req, k)
 				}
-				if iab.affs[k].res != v.res {
-					t.Errorf("Expected the return type %v,\n but got %v\n for RPC %v", v.res, iab.affs[k].res, k)
+				if iab.affs[k].Res != v.Res {
+					t.Errorf("Expected the return type %v,\n but got %v\n for RPC %v", v.Res, iab.affs[k].Res, k)
 				}
 			}
 		}
@@ -165,29 +165,29 @@ func TestConformRPC(t *testing.T) {
 
 var categorizeRPCTestAffordances = map[string]affs{
 	"SimpleTest": {
-		name: "SimpleTest",
-		req:  &wot.DataSchema{},
-		res:  &wot.DataSchema{},
+		Name: "SimpleTest",
+		Req:  &wot.DataSchema{},
+		Res:  &wot.DataSchema{},
 	},
 	"GetTest": {
-		name: "GetTest",
-		req:  &wot.DataSchema{},
-		res:  &wot.DataSchema{},
+		Name: "GetTest",
+		Req:  &wot.DataSchema{},
+		Res:  &wot.DataSchema{},
 	},
 	"GetTest2": {
-		name: "GetTest2",
-		req:  &wot.DataSchema{},
-		res:  &wot.DataSchema{},
+		Name: "GetTest2",
+		Req:  &wot.DataSchema{},
+		Res:  &wot.DataSchema{},
 	},
 	"SetTest": {
-		name: "SetTest",
-		req:  &wot.DataSchema{},
-		res:  &wot.DataSchema{},
+		Name: "SetTest",
+		Req:  &wot.DataSchema{},
+		Res:  &wot.DataSchema{},
 	},
 	"TestWithReturn": {
-		name: "TestWithReturn",
-		req:  &wot.DataSchema{},
-		res: &wot.DataSchema{
+		Name: "TestWithReturn",
+		Req:  &wot.DataSchema{},
+		Res: &wot.DataSchema{
 			DataType: "object",
 			ObjectSchema: &wot.ObjectSchema{
 				Properties: map[string]wot.DataSchema{
@@ -197,8 +197,8 @@ var categorizeRPCTestAffordances = map[string]affs{
 		},
 	},
 	"TestWithRequest": {
-		name: "TestWithRequest",
-		req: &wot.DataSchema{
+		Name: "TestWithRequest",
+		Req: &wot.DataSchema{
 			DataType: "object",
 			ObjectSchema: &wot.ObjectSchema{
 				Properties: map[string]wot.DataSchema{
@@ -206,11 +206,11 @@ var categorizeRPCTestAffordances = map[string]affs{
 				},
 			},
 		},
-		res: &wot.DataSchema{},
+		Res: &wot.DataSchema{},
 	},
 	"TestWithRequestAndReturn": {
-		name: "TestWithRequestAndReturn",
-		req: &wot.DataSchema{
+		Name: "TestWithRequestAndReturn",
+		Req: &wot.DataSchema{
 			DataType: "object",
 			ObjectSchema: &wot.ObjectSchema{
 				Properties: map[string]wot.DataSchema{
@@ -218,7 +218,7 @@ var categorizeRPCTestAffordances = map[string]affs{
 				},
 			},
 		},
-		res: &wot.DataSchema{
+		Res: &wot.DataSchema{
 			DataType: "object",
 			ObjectSchema: &wot.ObjectSchema{
 				Properties: map[string]wot.DataSchema{
@@ -365,28 +365,28 @@ var sameDataSets = map[string]*wot.DataSchema{
 
 var combinePropertiesTestAffordances = map[string]affs{
 	"GetTest1WithSameResAsSet": {
-		name: "GetTest1",
-		req:  &wot.DataSchema{},
-		res:  sameDataSets["DS1"],
+		Name: "GetTest1",
+		Req:  &wot.DataSchema{},
+		Res:  sameDataSets["DS1"],
 	},
 	"SetTest1WithSameReqAsGet": {
-		name: "SetTest1",
-		req:  sameDataSets["DS1"],
-		res:  &wot.DataSchema{},
+		Name: "SetTest1",
+		Req:  sameDataSets["DS1"],
+		Res:  &wot.DataSchema{},
 	},
 	"GetTest2WithDifferentResAsSet": {
-		name: "GetTest2",
-		req:  &wot.DataSchema{},
-		res:  sameDataSets["DS2"],
+		Name: "GetTest2",
+		Req:  &wot.DataSchema{},
+		Res:  sameDataSets["DS2"],
 	},
 	"SetTest2WithDifferentReqAsGet": {
-		name: "SetTest2",
-		req:  sameDataSets["DS3"],
-		res:  &wot.DataSchema{},
+		Name: "SetTest2",
+		Req:  sameDataSets["DS3"],
+		Res:  &wot.DataSchema{},
 	},
 	"GetTest3WithDifferentNameAndDifferentReqRes": {
-		name: "GetTest3Get",
-		req: &wot.DataSchema{
+		Name: "GetTest3Get",
+		Req: &wot.DataSchema{
 			DataType: "object",
 			ObjectSchema: &wot.ObjectSchema{
 				Properties: map[string]wot.DataSchema{
@@ -394,7 +394,7 @@ var combinePropertiesTestAffordances = map[string]affs{
 				},
 			},
 		},
-		res: &wot.DataSchema{
+		Res: &wot.DataSchema{
 			DataType: "object",
 			ObjectSchema: &wot.ObjectSchema{
 				Properties: map[string]wot.DataSchema{
@@ -404,8 +404,8 @@ var combinePropertiesTestAffordances = map[string]affs{
 		},
 	},
 	"SetTest3WithDifferentNameAndDifferentReqRes": {
-		name: "SetTest3Set",
-		req: &wot.DataSchema{
+		Name: "SetTest3Set",
+		Req: &wot.DataSchema{
 			DataType: "object",
 			ObjectSchema: &wot.ObjectSchema{
 				Properties: map[string]wot.DataSchema{
@@ -413,7 +413,7 @@ var combinePropertiesTestAffordances = map[string]affs{
 				},
 			},
 		},
-		res: &wot.DataSchema{
+		Res: &wot.DataSchema{
 			DataType: "object",
 			ObjectSchema: &wot.ObjectSchema{
 				Properties: map[string]wot.DataSchema{
@@ -440,10 +440,10 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:     "Test1",
-					getProp:  combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
-					setProp:  combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
-					category: 2,
+					Name:     "Test1",
+					GetProp:  combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
+					SetProp:  combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
+					Category: 2,
 				},
 			},
 		},
@@ -459,9 +459,9 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:     "Test1",
-					getProp:  combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
-					category: 0,
+					Name:     "Test1",
+					GetProp:  combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
+					Category: 0,
 				},
 			},
 		},
@@ -477,9 +477,9 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:     "Test1",
-					setProp:  combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
-					category: 1,
+					Name:     "Test1",
+					SetProp:  combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
+					Category: 1,
 				},
 			},
 		},
@@ -496,10 +496,10 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:     "Test1",
-					getProp:  combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
-					setProp:  combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
-					category: 2,
+					Name:     "Test1",
+					GetProp:  combinePropertiesTestAffordances["GetTest1WithSameResAsSet"],
+					SetProp:  combinePropertiesTestAffordances["SetTest1WithSameReqAsGet"],
+					Category: 2,
 				},
 			},
 		},
@@ -516,9 +516,9 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:     "Test2",
-					getProp:  combinePropertiesTestAffordances["GetTest2WithDifferentResAsSet"],
-					category: 0,
+					Name:     "Test2",
+					GetProp:  combinePropertiesTestAffordances["GetTest2WithDifferentResAsSet"],
+					Category: 0,
 				},
 			},
 			action: []affs{
@@ -538,14 +538,14 @@ var combinePropertiesTest = []struct {
 		affClasses{
 			combinedProp: []combinedProperties{
 				{
-					name:     "Test3Get",
-					getProp:  combinePropertiesTestAffordances["GetTest3WithDifferentNameAndDifferentReqRes"],
-					category: 0,
+					Name:     "Test3Get",
+					GetProp:  combinePropertiesTestAffordances["GetTest3WithDifferentNameAndDifferentReqRes"],
+					Category: 0,
 				},
 				{
-					name:     "Test3Set",
-					setProp:  combinePropertiesTestAffordances["SetTest3WithDifferentNameAndDifferentReqRes"],
-					category: 1,
+					Name:     "Test3Set",
+					SetProp:  combinePropertiesTestAffordances["SetTest3WithDifferentNameAndDifferentReqRes"],
+					Category: 1,
 				},
 			},
 		},
@@ -579,8 +579,8 @@ func equalsCombinedPropsSlice(e []combinedProperties, a []combinedProperties, t 
 }
 
 func equalsCombinedProps(a combinedProperties, b combinedProperties) bool {
-	return a.setProp == b.setProp &&
-		a.getProp == b.getProp &&
-		a.name == b.name &&
-		a.category == b.category
+	return a.SetProp == b.SetProp &&
+		a.GetProp == b.GetProp &&
+		a.Name == b.Name &&
+		a.Category == b.Category
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"github.com/Interactions-HSG/grpcwot"
+	"log"
+	"net/http"
+)
+
+func uploadHandler(w http.ResponseWriter, r *http.Request) {
+	setupResponse(&w, r)
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	err := r.ParseMultipartForm(32 << 20)
+	if err != nil {
+		return
+	}
+	file, _, err := r.FormFile("uploadfile")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer file.Close()
+	res, err := grpcwot.GetProtoBufInformation(file)
+	if err != nil {
+		return
+	}
+	_, err = w.Write(res)
+	if err != nil {
+		return
+	}
+	fmt.Println("successful")
+	fmt.Println(res)
+}
+
+func setupResponse(w *http.ResponseWriter, _ *http.Request) {
+	(*w).Header().Set("Access-Control-Allow-Origin", "*")
+	(*w).Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	(*w).Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+}
+
+func main() {
+	http.HandleFunc("/upload", uploadHandler)
+	fmt.Printf("Starting server at port 8080\n")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Working with the CLI has shown, that it is not ideal to perform Interaction Affordance Classification as the bigger picture gets lost by seeing each interaction affordance after another. The next problem was, that a mistake can not be corrected and everything has to be classified from the beginning.
To allow adding alternative classification user interfaces to the tool, apart from the CLI, a server is added.
The server can be questioned by handing over a Proto file and it will return the interaction affordances with DataSchemas with their checkCondition-based assignment to specific affordance classes+