### PR TITLE
Allow configuration-file-based classification

### DIFF
--- a/cmd/prototd/main.go
+++ b/cmd/prototd/main.go
@@ -25,10 +25,16 @@ func main() {
 				Usage: "The IP address for the gRPC serivce",
 			},
 			&cli.StringFlag{
-				Name:    "output",
+				Name:    "outputDir",
 				Aliases: []string{"o"},
-				Value:   "td.jsonld",
-				Usage:   "Write the resulting Thing Description to `FILE`",
+				Value:   "output",
+				Usage:   "Write the resulting Thing Description and files to `DIR`",
+			},
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Value:   "",
+				Usage:   "Load a configuration for affordance classification",
 			},
 		},
 		Name:  "prototd",
@@ -36,11 +42,16 @@ func main() {
 		Action: func(c *cli.Context) error {
 			protoFile := c.Args().Get(0)
 			if !strings.HasSuffix(protoFile, ".proto") {
-				return errors.New("The input file must be a .proto file")
+				return errors.New("the input file must be a .proto file")
 			} else if _, err := os.Stat(protoFile); errors.Is(err, os.ErrNotExist) {
 				return err
 			}
-			return grpcwot.GenerateTDfromProtoBuf(protoFile, c.String("output"), c.String("ip"), c.Int("port"))
+			return grpcwot.GenerateTDfromProtoBuf(
+				protoFile,
+				c.String("outputDir"),
+				c.String("config"),
+				c.String("ip"),
+				c.Int("port"))
 		},
 	}
 


### PR DESCRIPTION
To allow the user to rerun a specific generation with the same classification, the CLI produces classification files and is able to take them as input and execute the classification based on that. The user is then not required to interact over the CLI to approve or change affordance classifications.
- the applied classification of RPCs into interaction affordances is stored and returned to the user in the output directory
- the user can provide a configuration file to predefine the interaction affordance classification